### PR TITLE
[Feat] MainVC Animation debugging

### DIFF
--- a/FindAnimalFriends/FindAnimalFriends/View/ReadyView.swift
+++ b/FindAnimalFriends/FindAnimalFriends/View/ReadyView.swift
@@ -11,6 +11,12 @@ class ReadyView: UIView {
     
     private let subtitle = "자... 그럼 시작해볼까?"
     
+    let onboardingBlackView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black.withAlphaComponent(0.95)
+        return view
+    }()
+    
     private let detectiveView: UIImageView = {
         let imageView = UIImageView(image: UIImage(named: "detectiveImage3"))
         imageView.contentMode = .scaleAspectFit
@@ -28,8 +34,12 @@ class ReadyView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        addSubview(onboardingBlackView)
         addSubview(detectiveView)
         addSubview(textLabel)
+        
+        onboardingBlackView.frame = frame
+        
         makeConstraints()
         setupCodeName()
     }

--- a/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
+++ b/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
@@ -54,9 +54,6 @@ class MainViewController: UIViewController {
     private lazy var blackView: UIView = { // 어두운 방 느낌을 내기위한 뷰. mask당하는 뷰.
         let uiView = UIView(frame: UIScreen.main.bounds)
         uiView.backgroundColor = UIColor.black.withAlphaComponent(0.9)
-        if currentIndex == -1 {
-            uiView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(getReady)))
-        }
         return uiView
     }()
     
@@ -93,16 +90,16 @@ class MainViewController: UIViewController {
 private extension MainViewController {
     func setReady() {
         readyView = ReadyView(frame: UIScreen.main.bounds)
-        view.addSubview(blackView)
-        blackView.addSubview(readyView!)
+        readyView?.onboardingBlackView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(getReady)))
+        view.addSubview(readyView!)
     }
     
     @objc func getReady() {
-        blackView.removeGestureRecognizer(UITapGestureRecognizer())
-        UIView.transition(with: blackView,
+        UIView.transition(with: readyView!,
                           duration: 0.5, options: .transitionCrossDissolve) { [weak self] in
             self?.readyView!.removeFromSuperview()
         }
+        view.addSubview(blackView) // Remove ReadyView ~ setLight() 사이 1초동안 띄울용도
         UserDefaults.standard.set(0, forKey: "clear")
         Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { [weak self] _ in
             self?.currentIndex = 0
@@ -151,7 +148,7 @@ private extension MainViewController {
                 button.isUserInteractionEnabled = (Zoom.status == .zoomOut)
             }
         }
-        
+        // bug 1. 앱을 온보딩을 거치고 readyView를 거치고 온 후에만 나타나는 버그.
         maskLayerAnimation() // light(조명) 확대, 축소
         
         currentAnimal = memos[tag].memoAnimal.replacingOccurrences(of: "Memo", with: "")

--- a/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
+++ b/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
@@ -137,10 +137,11 @@ private extension MainViewController {
     }
     
     func zoomAction(tag: Int) {
+        
         UIView.animate(withDuration: 1.0, delay: 0, options: .curveEaseInOut) { [weak self] in
             guard let self = self else { return }
             
-            Zoom.status = (Zoom.status == .zoomIn ? .zoomOut : .zoomIn) // toggle
+            Zoom.status = (Zoom.status == .zoomIn ? .zoomOut : .zoomIn)
 
             self.backImageView.frame = self.memos[tag].backImageFrame //
             self.blackView.frame = self.backImageView.bounds // frame -> bounds로 수정 (fix)
@@ -178,9 +179,12 @@ private extension MainViewController {
         animation.duration = 1.0
         animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         maskLayer.add(animation, forKey: nil)
-        DispatchQueue.main.async {
+        // Remove DispatchQueue -> 비동기 할당으로 인해서 순간적인 버그가 일어나는 듯하여서 (추정)
+//        DispatchQueue.main.async {
+            //async로 돌렸기에 함수를 탈출. 1초 뒤에서야 호출이됨. 그 전까진 기존 위치 그대로인 것.
+            //변하는 동안 다다다다 누르면 순간적으로 실제 아직 변하지않은 위치의 layer가 뜨는 듯...
             self.maskLayer.path = path.cgPath
-        }
+//        }
     }
     
     func showEntranceView() {

--- a/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
+++ b/FindAnimalFriends/FindAnimalFriends/ViewController/MainViewController.swift
@@ -148,7 +148,7 @@ private extension MainViewController {
                 button.isUserInteractionEnabled = (Zoom.status == .zoomOut)
             }
         }
-        // bug 1. 앱을 온보딩을 거치고 readyView를 거치고 온 후에만 나타나는 버그.
+        
         maskLayerAnimation() // light(조명) 확대, 축소
         
         currentAnimal = memos[tag].memoAnimal.replacingOccurrences(of: "Memo", with: "")
@@ -176,12 +176,7 @@ private extension MainViewController {
         animation.duration = 1.0
         animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
         maskLayer.add(animation, forKey: nil)
-        // Remove DispatchQueue -> 비동기 할당으로 인해서 순간적인 버그가 일어나는 듯하여서 (추정)
-//        DispatchQueue.main.async {
-            //async로 돌렸기에 함수를 탈출. 1초 뒤에서야 호출이됨. 그 전까진 기존 위치 그대로인 것.
-            //변하는 동안 다다다다 누르면 순간적으로 실제 아직 변하지않은 위치의 layer가 뜨는 듯...
-            self.maskLayer.path = path.cgPath
-//        }
+        self.maskLayer.path = path.cgPath
     }
     
     func showEntranceView() {


### PR DESCRIPTION
# Bug 1. 짧은시간 touch를 빠르게 연타했을 때, mask layer의 위치가 통째로 이상한 곳으로 위치해버리는 문제
<img src="https://user-images.githubusercontent.com/95853235/180990211-34f7d274-785a-41c5-b684-d2b06aec6d22.png"  width="300" height="600"/>
- 테스트 결과, 온보딩을 거친 후에 나타나는 경우에서만 이런 이상현상이 발견됨.
- ReadyView(자...그럼 시작해볼까? 라는 멘트있는 뷰)를 blackView로부터 삭제하는 로직 + blackView에서 gestureRecognizer를 삭제하는 로직이 원인일 것이라 추정
- sol) readyView를 blackView의 subview로 넣지않고, readyView자체가 자신만의 onboardingBlackView를 가지도록 수정.


# Bug 2. 확대 - 축소 전환과정에서 빠르게 연타했을 때, 이동 전 원의 크기가 잠깐 그대로 뜨는 문제
<img src="https://user-images.githubusercontent.com/95853235/180990715-843d9d0a-9e51-43fa-b1f2-52669bb08933.png"  width="300" height="600"/>
- maskLayerAnimation() 함수 안에 있는 DispatchQueue.main.async 클로저가 원인이었던 것으로 추정됨
- Layer Animation은 1초에 걸쳐서 이뤄지는데 layer의 값을 할당하는 코드를 비동기 클로저 내부에 두어서 문제였음
- 디스패치 비동기 코드는 @escaping 탈출 클로저이기에 해당 함수가 끝난 후에야 실행됨. 즉 애니메이션이 발생하는 1초동안은 여전히 layer의 값이 변하지않은 상태이다. 그런과정에서 터치 연타를 했을 때 아직 미처 변하지않은 layer를 보여주는 것 같다.
- sol) DispatchQueue.main.async 클로저를 빼서 해결


- 추가적인 동작문제가 나타날 경우, 가능하면 화면 녹화해서 보내주시면 감사하겠습니다